### PR TITLE
fix for missing index check in consumer.cancel

### DIFF
--- a/dist/src/Broker.js
+++ b/dist/src/Broker.js
@@ -270,7 +270,7 @@ function Broker(owner) {
     queue.on('consume', (_, event) => consumers.push(event.content));
     queue.on('consumer.cancel', (_, event) => {
       const idx = consumers.indexOf(event.content);
-      consumers.splice(idx, 1);
+      if (idx !== -1) consumers.splice(idx, 1);
     });
     queues.push(queue);
     return queue;

--- a/src/Broker.js
+++ b/src/Broker.js
@@ -262,7 +262,8 @@ export function Broker(owner) {
     queue.on('consume', (_, event) => consumers.push(event.content));
     queue.on('consumer.cancel', (_, event) => {
       const idx = consumers.indexOf(event.content);
-      consumers.splice(idx, 1);
+
+      if (idx !== -1) consumers.splice(idx, 1);
     });
 
     queues.push(queue);

--- a/test/Broker-test.js
+++ b/test/Broker-test.js
@@ -1609,5 +1609,39 @@ describe('Smqp', () => {
         messages.push(msg);
       }
     });
+
+    it('double cancel of queue should not affect other consumers', () => {
+      const broker = Broker();
+
+      broker.assertExchange('event');
+      broker.assertExchange('event');
+
+      const queue1 = broker.assertQueue('queue1', { noAck: false });
+      const queue2 = broker.assertQueue('queue2', { noAck: false });
+
+      broker.bindQueue('queue1', 'event', 'test1.#');
+      broker.bindQueue('queue1', 'event', 'test2.#');
+
+      queue1.on('depleted', () => {
+        broker.cancel('2');
+        broker.cancel('2');
+      });
+
+      queue1.assertConsumer((key, msg) => msg.ack(), {
+        consumerTag: '2',
+      });
+
+      queue2.assertConsumer((key, msg) => msg.ack(), {
+        consumerTag: '1',
+      });
+
+      // Two consumers setup
+      expect(broker.consumerCount).to.equal(2);
+
+      // Publishing should trigger queue depeleted and remove one consumer
+      broker.publish('event', 'test1.something', 'important', {mandatory: true});
+
+      expect(broker.consumerCount).to.equal(1);
+    });
   });
 });


### PR DESCRIPTION
There's a missing index check when removing Broker consumers via consumer.cancel.  As a result, if a consumer has already been removed, consumer.cancel will splice out an unrelated consumer from the list, resulting in an un-cancellable consumer (still running in the queue, but invisible to the broker).

I encountered this in the wild with the _format-consumer in https://github.com/paed01/bpmn-elements/blob/master/src/activity/Activity.js#L697 .  The actual repro case there is complicated and related to the exact process and engine configuration I'm using, but the included test can reproduce the issue with a double cancel in the depleted callback.