### PR TITLE
Prototype/Class based optimizations

### DIFF
--- a/dist/src/Message.js
+++ b/dist/src/Message.js
@@ -7,79 +7,86 @@ exports.Message = Message;
 
 var _shared = require("./shared");
 
-function Message(fields = {}, content, properties = {}, onConsumed) {
-  let pending = false;
-  let consumedCallback;
-  const messageId = properties.messageId || `smq.mid-${(0, _shared.generateId)()}`;
-  const messageProperties = { ...properties,
-    messageId
-  };
-  const timestamp = messageProperties.timestamp = properties.timestamp || Date.now();
-  let ttl;
+const prv = Symbol('private');
+const publicMethods = ['consume', 'ack', 'nack', 'reject'];
 
-  if (properties.expiration) {
-    ttl = messageProperties.ttl = timestamp + parseInt(properties.expiration);
-  }
+class _Message {
+  constructor(fields = {}, content, properties = {}, onConsumed) {
+    this[prv] = {};
+    this[prv].onConsumed = onConsumed;
+    this[prv].pending = false;
+    this[prv].messageId = properties.messageId || `smq.mid-${(0, _shared.generateId)()}`;
+    const messageProperties = { ...properties,
+      messageId: this[prv].messageId
+    };
+    const timestamp = messageProperties.timestamp = properties.timestamp || Date.now();
 
-  const message = {
-    fields: { ...fields,
+    if (properties.expiration) {
+      this[prv].ttl = messageProperties.ttl = timestamp + parseInt(properties.expiration);
+    }
+
+    this.fields = { ...fields,
       consumerTag: undefined
-    },
-    content,
-    properties: messageProperties,
-
-    get messageId() {
-      return messageId;
-    },
-
-    get ttl() {
-      return ttl;
-    },
-
-    get consumerTag() {
-      return message.fields.consumerTag;
-    },
-
-    get pending() {
-      return pending;
-    },
-
-    consume,
-    ack,
-    nack,
-    reject
-  };
-  return message;
-
-  function consume({
-    consumerTag
-  } = {}, consumedCb) {
-    pending = true;
-    message.fields.consumerTag = consumerTag;
-    consumedCallback = consumedCb;
-  }
-
-  function reset() {
-    pending = false;
-  }
-
-  function ack(allUpTo) {
-    if (!pending) return;
-    consumed('ack', allUpTo);
-  }
-
-  function nack(allUpTo, requeue = true) {
-    if (!pending) return;
-    consumed('nack', allUpTo, requeue);
-  }
-
-  function reject(requeue = true) {
-    nack(false, requeue);
-  }
-
-  function consumed(operation, allUpTo, requeue) {
-    [consumedCallback, onConsumed, reset].forEach(fn => {
-      if (fn) fn(message, operation, allUpTo, requeue);
+    };
+    this.content = content;
+    this.properties = messageProperties;
+    publicMethods.forEach(fn => {
+      this[fn] = _Message.prototype[fn].bind(this);
     });
   }
+
+  get messageId() {
+    return this[prv].messageId;
+  }
+
+  get ttl() {
+    return this[prv].ttl;
+  }
+
+  get consumerTag() {
+    return this.fields.consumerTag;
+  }
+
+  get pending() {
+    return this[prv].pending;
+  }
+
+  consume({
+    consumerTag
+  } = {}, consumedCb) {
+    this[prv].pending = true;
+    this.fields.consumerTag = consumerTag;
+    this[prv].consumedCallback = consumedCb;
+  }
+
+  reset() {
+    this[prv].pending = false;
+  }
+
+  ack(allUpTo) {
+    if (this[prv].pending) {
+      this._consumed('ack', allUpTo);
+    }
+  }
+
+  nack(allUpTo, requeue = true) {
+    if (!this[prv].pending) return;
+
+    this._consumed('nack', allUpTo, requeue);
+  }
+
+  reject(requeue = true) {
+    this.nack(false, requeue);
+  }
+
+  _consumed(operation, allUpTo, requeue) {
+    [this[prv].consumedCallback, this[prv].onConsumed, this.reset.bind(this)].forEach(fn => {
+      if (fn) fn(this, operation, allUpTo, requeue);
+    });
+  }
+
+}
+
+function Message(fields = {}, content, properties = {}, onConsumed) {
+  return new _Message(fields, content, properties, onConsumed);
 }

--- a/src/Broker.js
+++ b/src/Broker.js
@@ -1,95 +1,110 @@
-import {Exchange, EventExchange} from './Exchange';
-import {Queue} from './Queue';
-import {Shovel} from './Shovel';
+import { Exchange, EventExchange } from './Exchange';
+import { Queue } from './Queue';
+import { Shovel } from './Shovel';
 
-export function Broker(owner) {
-  const exchanges = [];
-  const queues = [];
-  const consumers = [];
-  const shovels = [];
-  const events = EventExchange();
 
-  const broker = {
-    owner,
-    get exchangeCount() {
-      return exchanges.length;
-    },
-    get queueCount() {
-      return queues.length;
-    },
-    get consumerCount() {
-      return consumers.length;
-    },
-    subscribe,
-    subscribeOnce,
-    subscribeTmp,
-    unsubscribe,
-    createShovel,
-    closeShovel,
-    getShovel,
-    assertExchange,
-    ack,
-    ackAll,
-    nack,
-    nackAll,
-    cancel,
-    close,
-    deleteExchange,
-    bindExchange,
-    bindQueue,
-    assertQueue,
-    consume,
-    createQueue,
-    deleteQueue,
-    get: getMessageFromQueue,
-    getConsumer,
-    getConsumers,
-    getExchange,
-    getQueue,
-    getState,
-    on,
-    off,
-    prefetch: setPrefetch,
-    publish,
-    purgeQueue,
-    recover,
-    reject,
-    reset,
-    sendToQueue,
-    stop,
-    unbindExchange,
-    unbindQueue,
-  };
+const prv = Symbol('private');
 
-  return broker;
+const brokerPublicMethods = [
+  'subscribe',
+  'subscribeOnce',
+  'subscribeTmp',
+  'unsubscribe',
+  'createShovel',
+  'closeShovel',
+  'getShovel',
+  'assertExchange',
+  'ack',
+  'ackAll',
+  'nack',
+  'nackAll',
+  'cancel',
+  'close',
+  'deleteExchange',
+  'bindExchange',
+  'bindQueue',
+  'assertQueue',
+  'consume',
+  'createQueue',
+  'deleteQueue',
+  'getConsumer',
+  'getConsumers',
+  'getExchange',
+  'getQueue',
+  'getState',
+  'on',
+  'off',
+  'publish',
+  'purgeQueue',
+  'recover',
+  'reject',
+  'reset',
+  'sendToQueue',
+  'stop',
+  'unbindExchange',
+  'unbindQueue',
+];
 
-  function subscribe(exchangeName, pattern, queueName, onMessage, options = {durable: true}) {
+class _Broker {
+  constructor(owner) {
+
+    this[prv] = {
+      exchanges: [],
+      queues: [],
+      consumers: [],
+      shovels: [],
+      events: EventExchange(),
+    };
+
+    this.owner = owner;
+
+    brokerPublicMethods.forEach((fn) => {
+      this[fn] = _Broker.prototype[fn].bind(this);
+    });
+    // renamed methods
+    this.prefetch = _Broker.prototype.setPrefetch;
+    this.get = _Broker.prototype.getMessageFromQueue.bind(this);
+  }
+
+  get exchangeCount() {
+    return this[prv].exchanges.length;
+  }
+
+  get queueCount() {
+    return this[prv].queues.length;
+  }
+
+  get consumerCount() {
+    return this[prv].consumers.length;
+  }
+
+  subscribe(exchangeName, pattern, queueName, onMessage, options = { durable: true }) {
     if (!exchangeName || !pattern || typeof onMessage !== 'function') throw new Error('exchange name, pattern, and message callback are required');
-    if (options && options.consumerTag) validateConsumerTag(options.consumerTag);
+    if (options && options.consumerTag) this._validateConsumerTag(options.consumerTag);
 
-    assertExchange(exchangeName);
-    const queue = assertQueue(queueName, options);
+    this.assertExchange(exchangeName);
+    const queue = this.assertQueue(queueName, options);
 
-    bindQueue(queue.name, exchangeName, pattern, options);
+    this.bindQueue(queue.name, exchangeName, pattern, options);
 
-    return queue.assertConsumer(onMessage, options, owner);
+    return queue.assertConsumer(onMessage, options, this.owner);
   }
 
-  function subscribeTmp(exchangeName, pattern, onMessage, options = {}) {
-    return subscribe(exchangeName, pattern, null, onMessage, {...options, durable: false});
+  subscribeTmp(exchangeName, pattern, onMessage, options = {}) {
+    return this.subscribe(exchangeName, pattern, null, onMessage, { ...options, durable: false });
   }
 
-  function subscribeOnce(exchangeName, pattern, onMessage, options = {}) {
+  subscribeOnce(exchangeName, pattern, onMessage, options = {}) {
     if (typeof onMessage !== 'function') throw new Error('message callback is required');
-    if (options && options.consumerTag) validateConsumerTag(options.consumerTag);
+    if (options && options.consumerTag) this._validateConsumerTag(options.consumerTag);
 
-    assertExchange(exchangeName);
-    const onceOptions = {autoDelete: true, durable: false, priority: options.priority || 0};
-    const onceQueue = createQueue(null, onceOptions);
+    this.assertExchange(exchangeName);
+    const onceOptions = { autoDelete: true, durable: false, priority: options.priority || 0 };
+    const onceQueue = this.createQueue(null, onceOptions);
 
-    bindQueue(onceQueue.name, exchangeName, pattern, {...onceOptions});
+    this.bindQueue(onceQueue.name, exchangeName, pattern, { ...onceOptions });
 
-    return consume(onceQueue.name, wrappedOnMessage, {noAck: true, consumerTag: options.consumerTag});
+    return this.consume(onceQueue.name, wrappedOnMessage, { noAck: true, consumerTag: options.consumerTag });
 
     function wrappedOnMessage(...args) {
       onceQueue.delete();
@@ -97,163 +112,159 @@ export function Broker(owner) {
     }
   }
 
-  function unsubscribe(queueName, onMessage) {
-    const queue = getQueue(queueName);
+  unsubscribe(queueName, onMessage) {
+    const queue = this.getQueue(queueName);
     if (!queue) return;
     queue.dismiss(onMessage);
   }
 
-  function assertExchange(exchangeName, type, options) {
-    let exchange = getExchangeByName(exchangeName);
+  assertExchange(exchangeName, type, options) {
+    let exchange = this._getExchangeByName(exchangeName);
     if (exchange) {
       if (type && exchange.type !== type) throw new Error('Type doesn\'t match');
     } else {
       exchange = Exchange(exchangeName, type || 'topic', options);
       exchange.on('delete', () => {
-        const idx = exchanges.indexOf(exchange);
+        const idx = this[prv].exchanges.indexOf(exchange);
         if (idx === -1) return;
-        exchanges.splice(idx, 1);
+        this[prv].exchanges.splice(idx, 1);
       });
       exchange.on('return', (_, msg) => {
-        events.publish('return', msg.content);
+        this[prv].events.publish('return', msg.content);
       });
       exchange.on('message.undelivered', (_, msg) => {
-        events.publish('message.undelivered', msg.content);
+        this[prv].events.publish('message.undelivered', msg.content);
       });
-      exchanges.push(exchange);
+      this[prv].exchanges.push(exchange);
     }
 
     return exchange;
   }
 
-  function getExchangeByName(exchangeName) {
-    return exchanges.find((exchange) => exchange.name === exchangeName);
+  _getExchangeByName(exchangeName) {
+    return this[prv].exchanges.find((exchange) => exchange.name === exchangeName);
   }
 
-  function bindQueue(queueName, exchangeName, pattern, bindOptions) {
-    const exchange = getExchange(exchangeName);
-    const queue = getQueue(queueName);
+  bindQueue(queueName, exchangeName, pattern, bindOptions) {
+    const exchange = this.getExchange(exchangeName);
+    const queue = this.getQueue(queueName);
     exchange.bind(queue, pattern, bindOptions);
   }
 
-  function unbindQueue(queueName, exchangeName, pattern) {
-    const exchange = getExchange(exchangeName);
+  unbindQueue(queueName, exchangeName, pattern) {
+    const exchange = this.getExchange(exchangeName);
     if (!exchange) return;
-    const queue = getQueue(queueName);
+    const queue = this.getQueue(queueName);
     if (!queue) return;
     exchange.unbind(queue, pattern);
   }
 
-  function consume(queueName, onMessage, options) {
-    const queue = getQueue(queueName);
+  consume(queueName, onMessage, options) {
+    const queue = this.getQueue(queueName);
     if (!queue) throw new Error(`Queue with name <${queueName}> was not found`);
 
-    if (options) validateConsumerTag(options.consumerTag);
+    if (options) this._validateConsumerTag(options.consumerTag);
 
-    return queue.consume(onMessage, options, owner);
+    return queue.consume(onMessage, options, this.owner);
   }
 
-  function cancel(consumerTag) {
-    const consumer = getConsumer(consumerTag);
+  cancel(consumerTag) {
+    const consumer = this.getConsumer(consumerTag);
     if (!consumer) return false;
     consumer.cancel(false);
     return true;
   }
 
-  function getConsumers() {
-    return consumers.map((consumer) => {
+  getConsumers() {
+    return this[prv].consumers.map((consumer) => {
       return {
         queue: consumer.queue.name,
         consumerTag: consumer.options.consumerTag,
-        options: {...consumer.options}
+        options: { ...consumer.options }
       };
     });
   }
 
-  function getConsumer(consumerTag) {
-    return consumers.find((c) => c.consumerTag === consumerTag);
+  getConsumer(consumerTag) {
+    return this[prv].consumers.find((c) => c.consumerTag === consumerTag);
   }
 
-  function getExchange(exchangeName) {
-    return exchanges.find(({name}) => name === exchangeName);
+  getExchange(exchangeName) {
+    return this[prv].exchanges.find(({ name }) => name === exchangeName);
   }
 
-  function deleteExchange(exchangeName, {ifUnused} = {}) {
-    const idx = exchanges.findIndex((exchange) => exchange.name === exchangeName);
+  deleteExchange(exchangeName, { ifUnused } = {}) {
+    const idx = this[prv].exchanges.findIndex((exchange) => exchange.name === exchangeName);
     if (idx === -1) return false;
 
-    const exchange = exchanges[idx];
+    const exchange = this[prv].exchanges[idx];
     if (ifUnused && exchange.bindingCount) return false;
 
-    exchanges.splice(idx, 1);
+    this[prv].exchanges.splice(idx, 1);
     exchange.close();
     return true;
   }
 
-  function stop() {
-    for (const exchange of exchanges) exchange.stop();
-    for (const queue of queues) queue.stop();
+  stop() {
+    this[prv].exchanges.forEach((exchange) => exchange.stop());
+    this[prv].queues.forEach((queue) => queue.stop());
   }
 
-  function close() {
-    for (const shovel of shovels) shovel.close();
-    for (const exchange of exchanges) exchange.close();
-    for (const queue of queues) queue.close();
+  close() {
+    this[prv].shovels.forEach((shovel) => shovel.close());
+    this[prv].exchanges.forEach((exchange) => exchange.close());
+    this[prv].queues.forEach((queue) => queue.close());
   }
 
-  function reset() {
-    stop();
-    close();
-    exchanges.splice(0);
-    queues.splice(0);
-    consumers.splice(0);
-    shovels.splice(0);
+  reset() {
+    this.stop();
+    this.close();
+    this[prv].exchanges.splice(0);
+    this[prv].queues.splice(0);
+    this[prv].consumers.splice(0);
+    this[prv].shovels.splice(0);
   }
 
-  function getState() {
+  getState() {
     return {
-      exchanges: getExchangeState(),
-      queues: getQueuesState(),
+      exchanges: this.getExchangeState(),
+      queues: this.getQueuesState(),
     };
   }
 
-  function recover(state) {
-    if (state) {
-      if (state.queues) for (const qState of state.queues) recoverQueue(qState);
-      if (state.exchanges) for (const eState of state.exchanges) recoverExchange(eState);
-    } else {
-      for (const queue of queues) {
-        if (queue.stopped) queue.recover();
-      }
-      for (const exchange of exchanges) {
-        if (exchange.stopped) exchange.recover(null, getQueue);
-      }
-    }
-
-    return broker;
-
-    function recoverQueue(qState) {
-      const queue = assertQueue(qState.name, qState.options);
+  recover(state) {
+    const recoverQueue = (qState) => {
+      const queue = this.assertQueue(qState.name, qState.options);
       queue.recover(qState);
+    };
+
+    const recoverExchange = (eState) => {
+      const exchange = this.assertExchange(eState.name, eState.type, eState.options);
+      exchange.recover(eState, this.getQueue);
+    };
+
+    if (state) {
+      if (state.queues) state.queues.forEach(recoverQueue);
+      if (state.exchanges) state.exchanges.forEach(recoverExchange);
+    } else {
+      this[prv].queues.forEach((queue) => queue.stopped && queue.recover());
+      this[prv].exchanges.forEach((exchange) => exchange.stopped && exchange.recover(null, this.getQueue));
     }
 
-    function recoverExchange(eState) {
-      const exchange = assertExchange(eState.name, eState.type, eState.options);
-      exchange.recover(eState, getQueue);
-    }
+    return this;
   }
 
-  function bindExchange(source, destination, pattern = '#', args = {}) {
+  bindExchange(source, destination, pattern = '#', args = {}) {
     const name = `e2e-${source}2${destination}-${pattern}`;
-    const {priority} = args;
-    const {consumerTag, on: onShovel, close: onClose, source: shovelSource} = createShovel(name, {
-      broker,
+    const { priority } = args;
+    const { consumerTag, on: onShovel, close: onClose, source: shovelSource } = this.createShovel(name, {
+      broker: this,
       exchange: source,
       pattern,
       priority,
       consumerTag: `smq.ctag-${name}`,
     }, {
-      broker,
+      broker: this,
       exchange: destination
     }, {
       ...args
@@ -270,31 +281,31 @@ export function Broker(owner) {
     };
   }
 
-  function unbindExchange(source, destination, pattern = '#') {
+  unbindExchange(source, destination, pattern = '#') {
     const name = `e2e-${source}2${destination}-${pattern}`;
-    return closeShovel(name);
+    return this.closeShovel(name);
   }
 
-  function publish(exchangeName, routingKey, content, options) {
-    const exchange = getExchangeByName(exchangeName);
+  publish(exchangeName, routingKey, content, options) {
+    const exchange = this._getExchangeByName(exchangeName);
     if (!exchange) return;
     return exchange.publish(routingKey, content, options);
   }
 
-  function purgeQueue(queueName) {
-    const queue = getQueue(queueName);
+  purgeQueue(queueName) {
+    const queue = this.getQueue(queueName);
     if (!queue) return;
     return queue.purge();
   }
 
-  function sendToQueue(queueName, content, options = {}) {
-    const queue = getQueue(queueName);
+  sendToQueue(queueName, content, options = {}) {
+    const queue = this.getQueue(queueName);
     if (!queue) throw new Error(`Queue named ${queueName} doesn't exists`);
     return queue.queueMessage(null, content, options);
   }
 
-  function getQueuesState() {
-    return queues.reduce((result, queue) => {
+  getQueuesState() {
+    return this[prv].queues.reduce((result, queue) => {
       if (!queue.options.durable) return result;
       if (!result) result = [];
       result.push(queue.getState());
@@ -302,8 +313,8 @@ export function Broker(owner) {
     }, undefined);
   }
 
-  function getExchangeState() {
-    return exchanges.reduce((result, exchange) => {
+  getExchangeState() {
+    return this[prv].exchanges.reduce((result, exchange) => {
       if (!exchange.options.durable) return result;
       if (!result) result = [];
       result.push(exchange.getState());
@@ -311,114 +322,116 @@ export function Broker(owner) {
     }, undefined);
   }
 
-  function createQueue(queueName, options) {
-    if (getQueue(queueName)) throw new Error(`Queue named ${queueName} already exists`);
+  createQueue(queueName, options) {
+    if (this.getQueue(queueName)) throw new Error(`Queue named ${queueName} already exists`);
 
     const queue = Queue(queueName, options, EventExchange(queueName + '-events'));
-    queue.on('delete', onDelete);
-    queue.on('dead-letter', onDeadLetter);
-    queue.on('consume', (_, event) => consumers.push(event.content));
-    queue.on('consumer.cancel', (_, event) => {
-      const idx = consumers.indexOf(event.content);
-      if (idx !== -1) consumers.splice(idx, 1);
-    });
-    queue.on('message.consumed.#', (_, msg) => {
-      const {operation, message} = msg.content;
-      events.publish('message.' + operation, message);
-    });
 
-    queues.push(queue);
-    return queue;
-
-    function onDelete() {
-      const idx = queues.indexOf(queue);
+    const onDelete = () => {
+      const idx = this[prv].queues.indexOf(queue);
       if (idx === -1) return;
-      queues.splice(idx, 1);
-    }
+      this[prv].queues.splice(idx, 1);
+    };
 
-    function onDeadLetter(_, {content}) {
-      const exchange = getExchange(content.deadLetterExchange);
+    const onDeadLetter = (_, { content }) => {
+      const exchange = this.getExchange(content.deadLetterExchange);
       if (!exchange) return;
       exchange.publish(content.message.fields.routingKey, content.message.content, content.message.properties);
-    }
+    };
+
+    queue.on('delete', onDelete);
+    queue.on('dead-letter', onDeadLetter);
+    queue.on('consume', (_, event) => this[prv].consumers.push(event.content));
+    queue.on('consumer.cancel', (_, event) => {
+      const idx = this[prv].consumers.indexOf(event.content);
+      if (idx !== -1) this[prv].consumers.splice(idx, 1);
+    });
+    queue.on('message.consumed.#', (_, msg) => {
+      const { operation, message } = msg.content;
+      this[prv].events.publish('message.' + operation, message);
+    });
+
+    this[prv].queues.push(queue);
+    return queue;
   }
 
-  function getQueue(queueName) {
+  getQueue(queueName) {
     if (!queueName) return;
-    const idx = queues.findIndex((queue) => queue.name === queueName);
-    if (idx > -1) return queues[idx];
+    const idx = this[prv].queues.findIndex((queue) => queue.name === queueName);
+    if (idx > -1) return this[prv].queues[idx];
   }
 
-  function assertQueue(queueName, options = {}) {
-    if (!queueName) return createQueue(null, options);
+  assertQueue(queueName, options = {}) {
+    if (!queueName) return this.createQueue(null, options);
 
-    const queue = getQueue(queueName);
-    options = {durable: true, ...options};
-    if (!queue) return createQueue(queueName, options);
+    const queue = this.getQueue(queueName);
+    options = { durable: true, ...options };
+    if (!queue) return this.createQueue(queueName, options);
 
     if (queue.options.durable !== options.durable) throw new Error('Durable doesn\'t match');
     return queue;
   }
 
-  function deleteQueue(queueName, options) {
+  deleteQueue(queueName, options) {
     if (!queueName) return false;
-    const queue = getQueue(queueName);
+    const queue = this.getQueue(queueName);
     if (!queue) return false;
     return queue.delete(options);
   }
 
-  function getMessageFromQueue(queueName, {noAck} = {}) {
-    const queue = getQueue(queueName);
+  getMessageFromQueue(queueName, { noAck } = {}) {
+    const queue = this.getQueue(queueName);
     if (!queue) return;
 
-    return queue.get({noAck});
+    return queue.get({ noAck });
   }
 
-  function ack(message, allUpTo) {
+  ack(message, allUpTo) {
     message.ack(allUpTo);
   }
 
-  function ackAll() {
-    for (const queue of queues) queue.ackAll();
+  ackAll() {
+    this[prv].queues.forEach((queue) => queue.ackAll());
   }
 
-  function nack(message, allUpTo, requeue) {
+  nack(message, allUpTo, requeue) {
     message.nack(allUpTo, requeue);
   }
 
-  function nackAll(requeue) {
-    for (const queue of queues) queue.nackAll(requeue);
+  nackAll(requeue) {
+    this[prv].queues.forEach((queue) => queue.nackAll(requeue));
   }
 
-  function reject(message, requeue) {
+  reject(message, requeue) {
     message.reject(requeue);
   }
 
-  function validateConsumerTag(consumerTag) {
+  _validateConsumerTag(consumerTag) {
     if (!consumerTag) return true;
 
-    if (getConsumer(consumerTag)) {
+    if (this.getConsumer(consumerTag)) {
       throw new Error(`Consumer tag must be unique, ${consumerTag} is occupied`);
     }
 
     return true;
   }
 
-  function createShovel(name, source, destination, options) {
-    if (getShovel(name)) throw new Error(`Shovel name must be unique, ${name} is occupied`);
-    const shovel = Shovel(name, {...source, broker}, destination, options);
-    shovels.push(shovel);
+  createShovel(name, source, destination, options) {
+    if (this.getShovel(name)) throw new Error(`Shovel name must be unique, ${name} is occupied`);
+
+    const onClose = () => {
+      const idx = this[prv].shovels.indexOf(shovel);
+      if (idx > -1) this[prv].shovels.splice(idx, 1);
+    };
+
+    const shovel = Shovel(name, { ...source, broker: this }, destination, options);
+    this[prv].shovels.push(shovel);
     shovel.on('close', onClose);
     return shovel;
-
-    function onClose() {
-      const idx = shovels.indexOf(shovel);
-      if (idx > -1) shovels.splice(idx, 1);
-    }
   }
 
-  function closeShovel(name) {
-    const shovel = getShovel(name);
+  closeShovel(name) {
+    const shovel = this.getShovel(name);
     if (shovel) {
       shovel.close();
       return true;
@@ -426,12 +439,12 @@ export function Broker(owner) {
     return false;
   }
 
-  function getShovel(name) {
-    return shovels.find((s) => s.name === name);
+  getShovel(name) {
+    return this[prv].shovels.find((s) => s.name === name);
   }
 
-  function on(eventName, callback, options) {
-    return events.on(eventName, getEventCallback(), {...options, origin: callback});
+  on(eventName, callback, options) {
+    return this[prv].events.on(eventName, getEventCallback(), { ...options, origin: callback });
 
     function getEventCallback() {
       return function eventCallback(name, msg) {
@@ -443,9 +456,9 @@ export function Broker(owner) {
     }
   }
 
-  function off(eventName, callbackOrObject) {
-    const {consumerTag} = callbackOrObject;
-    for (const binding of events.bindings) {
+  off(eventName, callbackOrObject) {
+    const { consumerTag } = callbackOrObject;
+    for (const binding of this[prv].events.bindings) {
       if (binding.pattern === eventName) {
         if (consumerTag) {
           binding.queue.cancel(consumerTag);
@@ -461,5 +474,9 @@ export function Broker(owner) {
     }
   }
 
-  function setPrefetch() {}
+  setPrefetch() { }
+}
+
+export function Broker(owner) {
+  return new _Broker(owner);
 }

--- a/src/Exchange.js
+++ b/src/Exchange.js
@@ -1,283 +1,363 @@
-import {Message} from './Message';
-import {Queue} from './Queue';
-import {sortByPriority, getRoutingKeyPattern, generateId} from './shared';
+import { Message } from './Message';
+import { Queue } from './Queue';
+import { sortByPriority, getRoutingKeyPattern, generateId } from './shared';
 
-export {Exchange, EventExchange};
+export { Exchange, EventExchange };
 
 function Exchange(name, type, options) {
   const eventExchange = EventExchange();
-  return ExchangeBase(name, true, type, options, eventExchange);
+  return new ExchangeBase(name, true, type, options, eventExchange);
 }
 
 function EventExchange(name) {
   if (!name) name = `smq.ename-${generateId()}`;
-  return ExchangeBase(name, false, 'topic', {durable: false, autoDelete: true});
+  return new ExchangeBase(name, false, 'topic', {
+    durable: false,
+    autoDelete: true,
+  });
 }
 
-function ExchangeBase(name, isExchange, type = 'topic', options = {}, eventExchange) {
-  if (!name) throw new Error('Exchange name is required');
-  if (['topic', 'direct'].indexOf(type) === -1) throw Error('Exchange type must be one of topic or direct');
+const prv = Symbol('private');
 
-  const deliveryQueue = Queue('delivery-q', {}, {emit: onInternalQueueEmit});
-  let consumer = deliveryQueue.consume(type === 'topic' ? topic : direct);
-  if (!isExchange) eventExchange = undefined;
+const exchangePublicMethods = [
+  'bind',
+  'close',
+  'emit',
+  'getBinding',
+  'getState',
+  'on',
+  'off',
+  'publish',
+  'recover',
+  'stop',
+  'unbind',
+  'unbindQueueByName',
+];
 
-  const bindings = [];
-  let stopped;
-  options = {durable: true, autoDelete: true, ...options};
+class ExchangeBase {
+  constructor(name, isExchange, type = 'topic', options = {}, eventExchange) {
+    if (!name) throw new Error('Exchange name is required');
+    if (['topic', 'direct'].indexOf(type) === -1) {
+      throw Error('Exchange type must be one of topic or direct');
+    }
 
-  const exchange = {
-    name,
-    type,
-    options,
-    get bindingCount() {
-      return bindings.length;
-    },
-    get bindings() {
-      return bindings.slice();
-    },
-    get stopped() {
-      return stopped;
-    },
-    bind,
-    close,
-    emit,
-    getBinding,
-    getState,
-    on,
-    off,
-    publish,
-    recover,
-    stop,
-    unbind,
-    unbindQueueByName,
-  };
+    const deliveryQueue = Queue(
+      'delivery-q',
+      {},
+      { emit: ExchangeBase.prototype._onInternalQueueEmit.bind(this) }
+    );
+    const consumerCallback = ExchangeBase.prototype[type];
+    const consumer = deliveryQueue.consume(consumerCallback.bind(this));
+    if (!isExchange) eventExchange = undefined;
 
-  return exchange;
+    this[prv] = {
+      isExchange,
+      deliveryQueue,
+      consumer,
+      eventExchange,
+      bindings: [],
+      stopped: undefined,
+    };
 
-  function publish(routingKey, content, properties = {}) {
-    if (!shouldIPublish(properties)) return;
-    return deliveryQueue.queueMessage({routingKey}, {
-      content,
-      properties,
+    this.name = name;
+    this.type = type;
+    this.options = { durable: true, autoDelete: true, ...options };
+
+    exchangePublicMethods.forEach((fn) => {
+      this[fn] = ExchangeBase.prototype[fn].bind(this);
     });
   }
 
-  function shouldIPublish(messageProperties) {
-    if (stopped) return;
-    if (messageProperties.mandatory || messageProperties.confirm) return true;
-    return bindings.length;
+  get bindingCount() {
+    return this[prv].bindings.length;
   }
 
-  function topic(routingKey, message) {
-    const deliverTo = getConcernedBindings(routingKey);
+  get bindings() {
+    return this[prv].bindings.slice();
+  }
+
+  get stopped() {
+    return this[prv].stopped;
+  }
+
+  publish(routingKey, content, properties = {}) {
+    if (!this._shouldIPublish(properties)) return;
+    return this[prv].deliveryQueue.queueMessage(
+      { routingKey },
+      {
+        content,
+        properties,
+      }
+    );
+  }
+
+  _shouldIPublish(messageProperties) {
+    if (this[prv].stopped) return;
+    if (messageProperties.mandatory || messageProperties.confirm) return true;
+    return this[prv].bindings.length;
+  }
+
+  topic(routingKey, message) {
+    const deliverTo = this._getConcernedBindings(routingKey);
     const publishedMsg = message.content;
 
     if (!deliverTo.length) {
       message.ack();
-      emitReturn(routingKey, publishedMsg);
+      this._emitReturn(routingKey, publishedMsg);
       return 0;
     }
 
     message.ack();
-    deliverTo.forEach(({queue}) => publishToQueue(queue, routingKey, publishedMsg.content, publishedMsg.properties));
+    deliverTo.forEach(({ queue }) =>
+      this.publishToQueue(
+        queue,
+        routingKey,
+        publishedMsg.content,
+        publishedMsg.properties
+      )
+    );
   }
 
-  function direct(routingKey, message) {
-    const deliverTo = getConcernedBindings(routingKey);
+  direct(routingKey, message) {
+    const deliverTo = this._getConcernedBindings(routingKey);
     const publishedMsg = message.content;
 
     const first = deliverTo[0];
     if (!first) {
       message.ack();
-      emitReturn(routingKey, publishedMsg);
+      this._emitReturn(routingKey, publishedMsg);
       return 0;
     }
 
-    if (deliverTo.length > 1) shift(deliverTo[0]);
+    if (deliverTo.length > 1) this._shift(deliverTo[0]);
 
     message.ack();
-    publishToQueue(first.queue, routingKey, publishedMsg.content, publishedMsg.properties);
+    this.publishToQueue(
+      first.queue,
+      routingKey,
+      publishedMsg.content,
+      publishedMsg.properties
+    );
   }
 
-  function publishToQueue(queue, routingKey, content, properties) {
-    queue.queueMessage({routingKey, exchange: name}, content, properties);
+  publishToQueue(queue, routingKey, content, properties) {
+    queue.queueMessage({ routingKey, exchange: this.name }, content, properties);
   }
 
-  function emitReturn(routingKey, returnMessage) {
-    const {content, properties} = returnMessage;
+  _emitReturn(routingKey, returnMessage) {
+    const { content, properties } = returnMessage;
     if (properties.confirm) {
-      emit('message.undelivered', Message({routingKey, exchange: name}, content, properties));
+      this.emit(
+        'message.undelivered',
+        Message({ routingKey, exchange: this.name }, content, properties)
+      );
     }
     if (properties.mandatory) {
-      emit('return', Message({routingKey, exchange: name}, content, properties));
+      this.emit(
+        'return',
+        Message({ routingKey, exchange: this.name }, content, properties)
+      );
     }
   }
 
-  function getConcernedBindings(routingKey) {
-    return bindings.reduce((result, bound) => {
+  _getConcernedBindings(routingKey) {
+    return this[prv].bindings.reduce((result, bound) => {
       if (bound.testPattern(routingKey)) result.push(bound);
       return result;
     }, []);
   }
 
-  function shift(bound) {
-    const idx = bindings.indexOf(bound);
-    bindings.splice(idx, 1);
-    bindings.push(bound);
+  _shift(bound) {
+    const idx = this[prv].bindings.indexOf(bound);
+    this[prv].bindings.splice(idx, 1);
+    this[prv].bindings.push(bound);
   }
 
-  function bind(queue, pattern, bindOptions) {
-    const bound = bindings.find((bq) => bq.queue === queue && bq.pattern === pattern);
+  bind(queue, pattern, bindOptions) {
+    const bound = this[prv].bindings.find(
+      (bq) => bq.queue === queue && bq.pattern === pattern
+    );
     if (bound) return bound;
 
-    const binding = Binding(queue, pattern, bindOptions);
-    bindings.push(binding);
-    bindings.sort(sortByPriority);
+    const binding = new Binding(queue, pattern, bindOptions, this);
+    this[prv].bindings.push(binding);
+    this[prv].bindings.sort(sortByPriority);
 
-    emit('bind', binding);
+    this.emit('bind', binding);
 
     return binding;
   }
 
-  function unbind(queue, pattern) {
-    const idx = bindings.findIndex((bq) => bq.queue === queue && bq.pattern === pattern);
+  unbind(queue, pattern) {
+    const idx = this[prv].bindings.findIndex(
+      (bq) => bq.queue === queue && bq.pattern === pattern
+    );
     if (idx === -1) return;
 
-    const [binding] = bindings.splice(idx, 1);
+    const [binding] = this[prv].bindings.splice(idx, 1);
     binding.close();
 
-    emit('unbind', binding);
+    this.emit('unbind', binding);
 
-    if (!bindings.length && options.autoDelete) emit('delete', exchange);
+    if (!this[prv].bindings.length && this.options.autoDelete) {
+      this.emit('delete', this);
+    }
   }
 
-  function unbindQueueByName(queueName) {
-    const bounds = bindings.filter((bq) => bq.queue.name === queueName);
+  unbindQueueByName(queueName) {
+    const bounds = this[prv].bindings.filter(
+      (bq) => bq.queue.name === queueName
+    );
     bounds.forEach((bound) => {
-      unbind(bound.queue, bound.pattern);
+      this.unbind(bound.queue, bound.pattern);
     });
   }
 
-  function close() {
-    bindings.slice().forEach((binding) => binding.close());
-    deliveryQueue.unbindConsumer(consumer);
-    deliveryQueue.close();
+  close() {
+    this[prv].bindings.slice().forEach((binding) => binding.close());
+    this[prv].deliveryQueue.unbindConsumer(this[prv].consumer);
+    this[prv].deliveryQueue.close();
   }
 
-  function getState() {
-    return {
-      name,
-      type,
-      options: {...options},
-      ...(deliveryQueue.messageCount ? {deliveryQueue: deliveryQueue.getState()} : undefined),
-      bindings: getBoundState()
-    };
-
-    function getBoundState() {
-      return bindings.reduce((result, binding) => {
+  getState() {
+    const getBoundState = () => {
+      return this[prv].bindings.reduce((result, binding) => {
         if (!binding.queue.options.durable) return result;
         if (!result) result = [];
         result.push(binding.getState());
         return result;
       }, undefined);
-    }
+    };
+
+    return {
+      name: this.name,
+      type: this.type,
+      options: { ...this.options },
+      ...(this[prv].deliveryQueue.messageCount
+        ? { deliveryQueue: this[prv].deliveryQueue.getState() }
+        : undefined),
+      bindings: getBoundState(),
+    };
   }
 
-  function stop() {
-    stopped = true;
+  stop() {
+    this[prv].stopped = true;
   }
 
-  function recover(state, getQueue) {
-    stopped = false;
+  recover(state, getQueue) {
+    this[prv].stopped = false;
 
-    recoverBindings();
-    if (state) {
-      name = exchange.name = state.name;
-      deliveryQueue.recover(state.deliveryQueue);
-      consumer = deliveryQueue.consume(type === 'topic' ? topic : direct);
+    if (!state) {
+      return this;
     }
 
-    return exchange;
-
-    function recoverBindings() {
-      if (!state || !state.bindings) return;
+    if (state.bindings) {
       state.bindings.forEach((bindingState) => {
         const queue = getQueue(bindingState.queueName);
         if (!queue) return;
-        bind(queue, bindingState.pattern, bindingState.options);
+        this.bind(queue, bindingState.pattern, bindingState.options);
       });
     }
+
+    this.name = state.name;
+    this[prv].deliveryQueue.recover(state.deliveryQueue);
+    this[prv].consumer = this[prv].deliveryQueue.consume(
+      ExchangeBase.prototype[this.type].bind(this)
+    );
+
+    return this;
   }
 
-  function getBinding(queueName, pattern) {
-    return bindings.find((binding) => binding.queue.name === queueName && binding.pattern === pattern);
+  getBinding(queueName, pattern) {
+    return this[prv].bindings.find(
+      (binding) =>
+        binding.queue.name === queueName && binding.pattern === pattern
+    );
   }
 
-  function emit(eventName, content) {
-    if (isExchange) return eventExchange.publish(`exchange.${eventName}`, content);
-    publish(eventName, content);
+  emit(eventName, content) {
+    if (this[prv].isExchange) {
+      return this[prv].eventExchange.publish(`exchange.${eventName}`, content);
+    }
+    this.publish(eventName, content);
   }
 
-  function on(pattern, handler, consumeOptions = {}) {
-    if (isExchange) return eventExchange.on(`exchange.${pattern}`, handler, consumeOptions);
+  on(pattern, handler, consumeOptions = {}) {
+    if (this[prv].isExchange) {
+      return this[prv].eventExchange.on(`exchange.${pattern}`, handler, consumeOptions);
+    }
 
-    const eventQueue = Queue(null, {durable: false, autoDelete: true});
-    bind(eventQueue, pattern);
-    const eventConsumer = eventQueue.consume(handler, {...consumeOptions, noAck: true}, exchange);
+    const eventQueue = Queue(null, { durable: false, autoDelete: true });
+    this.bind(eventQueue, pattern);
+    const eventConsumer = eventQueue.consume(
+      handler,
+      { ...consumeOptions, noAck: true },
+      this
+    );
     return eventConsumer;
   }
 
-  function off(pattern, handler) {
-    if (isExchange) return eventExchange.off(`exchange.${pattern}`, handler);
+  off(pattern, handler) {
+    if (this[prv].isExchange) return this[prv].eventExchange.off(`exchange.${pattern}`, handler);
 
-    const {consumerTag} = handler;
-    for (const binding of bindings) {
+    const { consumerTag } = handler;
+    for (const binding of this[prv].bindings) {
       if (binding.pattern === pattern) {
         if (consumerTag) binding.queue.cancel(consumerTag);
         binding.queue.dismiss(handler);
       }
     }
   }
+  _onInternalQueueEmit() { }
+}
 
-  function Binding(queue, pattern, bindOptions = {}) {
-    const rPattern = getRoutingKeyPattern(pattern);
-    queue.on('delete', closeBinding);
+const bindingPublicMethods = [
+  'close',
+  'testPattern',
+  'getState',
+];
+class Binding {
+  constructor(queue, pattern, bindOptions = {}, exchange) {
 
-    const binding = {
-      id: `${queue.name}/${pattern}`,
-      options: {priority: 0, ...bindOptions},
-      pattern,
-      get queue() {
-        return queue;
-      },
-      get queueName() {
-        return queue.name;
-      },
-      close: closeBinding,
-      testPattern,
-      getState: getBindingState,
+    this[prv] = {
+      rPattern: getRoutingKeyPattern(pattern),
+      exchange,
+      queue
     };
 
-    return binding;
+    this.id = `${queue.name}/${pattern}`;
+    this.options = { priority: 0, ...bindOptions };
+    this.pattern = pattern;
 
-    function testPattern(routingKey) {
-      return rPattern.test(routingKey);
-    }
+    bindingPublicMethods.forEach((fn) => {
+      this[fn] = Binding.prototype[fn].bind(this);
+    });
 
-    function closeBinding() {
-      unbind(queue, pattern);
-    }
-
-    function getBindingState() {
-      return {
-        id: binding.id,
-        options: {...binding.options},
-        queueName: binding.queueName,
-        pattern,
-      };
-    }
+    queue.on('delete', this.close);
   }
 
-  function onInternalQueueEmit() {}
+  get queue() {
+    return this[prv].queue;
+  }
+
+  get queueName() {
+    return this[prv].queue.name;
+  }
+
+  testPattern(routingKey) {
+    return this[prv].rPattern.test(routingKey);
+  }
+
+  close() {
+    this[prv].exchange.unbind(this[prv].queue, this.pattern);
+  }
+
+  getState() {
+    return {
+      id: this.id,
+      options: { ...this.options },
+      queueName: this.queueName,
+      pattern: this.pattern,
+    };
+  }
 }

--- a/src/Queue.js
+++ b/src/Queue.js
@@ -1,109 +1,135 @@
-import {generateId, sortByPriority} from './shared';
-import {Message} from './Message';
+import { generateId, sortByPriority } from './shared';
+import { Message } from './Message';
 
-export {Queue, Consumer};
+export { Queue, Consumer };
 
-function Queue(name, options = {}, eventEmitter) {
-  if (!name) name = `smq.qname-${generateId()}`;
+const prv = Symbol('private');
 
-  const messages = [], consumers = [];
-  let exclusivelyConsumed, stopped, pendingMessageCount = 0;
-  options = {autoDelete: true, ...options};
+const queuePublicMethods = [
+  'ack',
+  'ackAll',
+  'assertConsumer',
+  'cancel',
+  'close',
+  'consume',
+  'delete',
+  'dequeueMessage',
+  'dismiss',
+  'get',
+  'getState',
+  'nack',
+  'nackAll',
+  'off',
+  'on',
+  'peek',
+  'purge',
+  'queueMessage',
+  'recover',
+  'reject',
+  'stop',
+  'unbindConsumer',
+];
 
-  let maxLength = 'maxLength' in options ? options.maxLength : Infinity;
-  const messageTtl = options.messageTtl;
+class _Queue {
+  constructor(name, options = {}, eventEmitter) {
+    this[prv] = {
+      eventEmitter,
+      consumers: [],
+      pendingMessageCount: 0,
+      onMessageConsumed: _Queue.prototype._onMessageConsumed.bind(this),
+    };
 
-  const {deadLetterExchange, deadLetterRoutingKey} = options;
+    this.name = name || `smq.qname-${generateId()}`;
+    this.options = { autoDelete: true, ...options };
+    if (this.options.maxLength === undefined) {
+      this.options.maxLength = Infinity;
+    }
 
-  const queue = {
-    name,
-    options,
-    get messageCount() {
-      return messages.length;
-    },
-    get consumers() {
-      return consumers.slice();
-    },
-    get consumerCount() {
-      return consumers.length;
-    },
-    get stopped() {
-      return stopped;
-    },
-    get exclusive() {
-      return exclusivelyConsumed;
-    },
-    get maxLength() {
-      return maxLength;
-    },
-    set maxLength(value) {
-      maxLength = options.maxLength = value;
-    },
-    get capacity() {
-      return getCapacity();
-    },
-    messages,
-    ack,
-    ackAll,
-    assertConsumer,
-    cancel,
-    close,
-    consume,
-    delete: deleteQueue,
-    dequeueMessage,
-    dismiss,
-    get,
-    getState,
-    nack,
-    nackAll,
-    off,
-    on,
-    peek,
-    purge,
-    queueMessage,
-    recover,
-    reject,
-    stop,
-    unbindConsumer,
-  };
+    this.messages = [];
 
-  return queue;
+    queuePublicMethods.forEach((fn) => {
+      this[fn] = _Queue.prototype[fn].bind(this);
+    });
+  }
 
-  function queueMessage(fields, content, properties, onMessageQueued) {
-    if (stopped) return;
+  get messageCount() {
+    return this.messages.length;
+  }
 
-    const messageProperties = {...properties};
-    if (messageTtl) messageProperties.expiration = messageProperties.expiration || messageTtl;
-    const message = Message(fields, content, messageProperties, onMessageConsumed);
+  get consumers() {
+    return this[prv].consumers.slice();
+  }
 
-    const capacity = getCapacity();
-    messages.push(message);
-    pendingMessageCount++;
+  get consumerCount() {
+    return this[prv].consumers.length;
+  }
+
+  get stopped() {
+    return this[prv].stopped;
+  }
+
+  get exclusive() {
+    return this[prv].exclusivelyConsumed;
+  }
+
+  get maxLength() {
+    return this.options.maxLength;
+  }
+
+  set maxLength(maxLength) {
+    this.options.maxLength = maxLength;
+  }
+
+  get capacity() {
+    return this.getCapacity();
+  }
+
+  queueMessage(fields, content, properties, onMessageQueued) {
+    if (this[prv].stopped) return;
+
+    const messageProperties = { ...properties };
+    const messageTtl = this.options.messageTtl;
+
+    if (messageTtl) {
+      messageProperties.expiration = messageProperties.expiration || messageTtl;
+    }
+    const message = Message(
+      fields,
+      content,
+      messageProperties,
+      this[prv].onMessageConsumed
+    );
+
+    const capacity = this.getCapacity();
+    this.messages.push(message);
+    this[prv].pendingMessageCount++;
 
     let discarded;
+
+    const evictOld = () => {
+      const evict = this.get();
+      if (!evict) return;
+      evict.nack(false, false);
+      return evict === message;
+    };
+
     switch (capacity) {
       case 0:
         discarded = evictOld();
       case 1:
-        emit('saturated');
+        this._emit('saturated');
     }
 
     if (onMessageQueued) onMessageQueued(message);
-    emit('message', message);
+    this._emit('message', message);
 
-    return discarded ? 0 : consumeNext();
-
-    function evictOld() {
-      const evict = get();
-      if (!evict) return;
-      evict.nack(false, false);
-      return evict === message;
-    }
+    return discarded ? 0 : this._consumeNext();
   }
 
-  function consumeNext() {
-    if (stopped) return;
-    if (!pendingMessageCount) return;
+  _consumeNext() {
+    const consumers = this[prv].consumers;
+    if (this[prv].stopped) return;
+    if (!this[prv].pendingMessageCount) return;
     if (!consumers.length) return;
 
     const readyConsumers = consumers.filter((consumer) => consumer.ready);
@@ -111,7 +137,7 @@ function Queue(name, options = {}, eventEmitter) {
 
     let consumed = 0;
     for (const consumer of readyConsumers) {
-      const msgs = consumeMessages(consumer.capacity, consumer.options);
+      const msgs = this._consumeMessages(consumer.capacity, consumer.options);
       if (!msgs.length) return consumed;
       consumer.push(msgs);
       consumed += msgs.length;
@@ -120,136 +146,170 @@ function Queue(name, options = {}, eventEmitter) {
     return consumed;
   }
 
-  function consume(onMessage, consumeOptions = {}, owner) {
-    if (exclusivelyConsumed && consumers.length) throw new Error(`Queue ${name} is exclusively consumed by ${consumers[0].consumerTag}`);
-    else if (consumeOptions.exclusive && consumers.length) throw new Error(`Queue ${name} already has consumers and cannot be exclusively consumed`);
+  consume(onMessage, consumeOptions = {}, owner) {
+    const consumers = this[prv].consumers;
 
-    const consumer = Consumer(queue, onMessage, consumeOptions, owner, consumerEmitter());
+    if (this[prv].exclusivelyConsumed && consumers.length) {
+      throw new Error(
+        `Queue ${this.name} is exclusively consumed by ${consumers[0].consumerTag}`
+      );
+    } else if (consumeOptions.exclusive && consumers.length) {
+      throw new Error(
+        `Queue ${this.name} already has consumers and cannot be exclusively consumed`
+      );
+    }
+
+    const consumerEmitter = {
+      emit: (eventName, ...args) => {
+        if (eventName === 'consumer.cancel') {
+          this.unbindConsumer(consumer);
+        }
+        this._emit(eventName, ...args);
+      },
+      on: this.on,
+    };
+
+    const consumer = Consumer(
+      this,
+      onMessage,
+      consumeOptions,
+      owner,
+      consumerEmitter
+    );
     consumers.push(consumer);
     consumers.sort(sortByPriority);
 
-    exclusivelyConsumed = consumer.options.exclusive;
+    this[prv].exclusivelyConsumed = consumer.options.exclusive;
 
-    emit('consume', consumer);
+    this._emit('consume', consumer);
 
-    const pendingMessages = consumeMessages(consumer.capacity, consumer.options);
+    const pendingMessages = this._consumeMessages(
+      consumer.capacity,
+      consumer.options
+    );
     if (pendingMessages.length) consumer.push(pendingMessages);
 
     return consumer;
-
-    function consumerEmitter() {
-      return {
-        emit: onConsumerEmit,
-        on,
-      };
-
-      function onConsumerEmit(eventName, ...args) {
-        if (eventName === 'consumer.cancel') {
-          unbindConsumer(consumer);
-        }
-        emit(eventName, ...args);
-      }
-    }
   }
 
-  function assertConsumer(onMessage, consumeOptions = {}, owner) {
-    if (!consumers.length) return consume(onMessage, consumeOptions, owner);
+  assertConsumer(onMessage, consumeOptions = {}, owner) {
+    const consumers = this[prv].consumers;
+
+    if (!consumers.length) {
+      return this.consume(onMessage, consumeOptions, owner);
+    }
     for (const consumer of consumers) {
       if (consumer.onMessage !== onMessage) continue;
 
-      if (consumeOptions.consumerTag && consumeOptions.consumerTag !== consumer.consumerTag) {
+      if (
+        consumeOptions.consumerTag &&
+        consumeOptions.consumerTag !== consumer.consumerTag
+      ) {
         continue;
-      } else if ('exclusive' in consumeOptions && consumeOptions.exclusive !== consumer.options.exclusive) {
+      } else if (
+        'exclusive' in consumeOptions &&
+        consumeOptions.exclusive !== consumer.options.exclusive
+      ) {
         continue;
       }
 
       return consumer;
     }
-    return consume(onMessage, consumeOptions, owner);
+    return this.consume(onMessage, consumeOptions, owner);
   }
 
-  function get({noAck, consumerTag} = {}) {
-    const message = consumeMessages(1, {noAck, consumerTag})[0];
+  get({ noAck, consumerTag } = {}) {
+    const message = this._consumeMessages(1, { noAck, consumerTag })[0];
     if (!message) return;
-    if (noAck) dequeue(message);
+    if (noAck) this._dequeue(message);
 
     return message;
   }
 
-  function consumeMessages(n, consumeOptions) {
-    if (stopped || !pendingMessageCount || !n) return [];
+  _consumeMessages(n, consumeOptions) {
+    if (this[prv].stopped || !this[prv].pendingMessageCount || !n) return [];
 
     const now = Date.now();
     const msgs = [];
     const evict = [];
-    for (const message of messages) {
+    for (const message of this.messages) {
       if (message.pending) continue;
       if (message.ttl && message.ttl < now) {
         evict.push(message);
         continue;
       }
       message.consume(consumeOptions);
-      pendingMessageCount--;
+      this[prv].pendingMessageCount--;
       msgs.push(message);
       if (!--n) break;
     }
 
-    for (const expired of evict) nack(expired, false, false);
+    for (const expired of evict) this.nack(expired, false, false);
 
     return msgs;
   }
 
-  function ack(message, allUpTo) {
-    onMessageConsumed(message, 'ack', allUpTo);
+  ack(message, allUpTo) {
+    this[prv].onMessageConsumed(message, 'ack', allUpTo);
   }
 
-  function nack(message, allUpTo, requeue = true) {
-    onMessageConsumed(message, 'nack', allUpTo, requeue);
+  nack(message, allUpTo, requeue = true) {
+    this[prv].onMessageConsumed(message, 'nack', allUpTo, requeue);
   }
 
-  function reject(message, requeue = true) {
-    onMessageConsumed(message, 'nack', false, requeue);
+  reject(message, requeue = true) {
+    this[prv].onMessageConsumed(message, 'nack', false, requeue);
   }
 
-  function onMessageConsumed(message, operation, allUpTo, requeue) {
-    if (stopped) return;
-    const pending = allUpTo && getPendingMessages(message);
-    const {properties} = message;
+  _onMessageConsumed(message, operation, allUpTo, requeue) {
+    if (this[prv].stopped) return;
+    const pending = allUpTo && this._getPendingMessages(message);
+    const { properties } = message;
 
     let deadLetter = false;
     switch (operation) {
       case 'ack': {
-        if (!dequeue(message)) return;
+        if (!this._dequeue(message)) return;
         break;
       }
       case 'nack':
         if (requeue) {
-          requeueMessage(message);
+          this._requeueMessage(message);
           break;
         }
 
-        if (!dequeue(message)) return;
-        deadLetter = !!deadLetterExchange;
+        if (!this._dequeue(message)) return;
+        deadLetter = !!this.options.deadLetterExchange;
         break;
     }
 
     let capacity;
-    if (!messages.length) emit('depleted', queue);
-    else if ((capacity = getCapacity()) === 1) emit('ready', capacity);
+    if (!this.messages.length) this._emit('depleted', this);
+    else if ((capacity = this.getCapacity()) === 1) {
+      this._emit('ready', capacity);
+    }
 
-    if (!pending || !pending.length) consumeNext();
+    if (!pending || !pending.length) this._consumeNext();
 
     if (!requeue && properties.confirm) {
-      emit('message.consumed.' + operation, {operation, message: {...message}});
+      this._emit('message.consumed.' + operation, {
+        operation,
+        message: { ...message },
+      });
     }
 
     if (deadLetter) {
-      const deadMessage = Message(message.fields, message.content, {...properties, expiration: undefined});
-      if (deadLetterRoutingKey) deadMessage.fields.routingKey = deadLetterRoutingKey;
+      const deadMessage = Message(message.fields, message.content, {
+        ...properties,
+        expiration: undefined,
+      });
+      if (this.options.deadLetterRoutingKey) {
+        deadMessage.fields.routingKey = this.options.deadLetterRoutingKey;
+      }
 
-      emit('dead-letter', {
-        deadLetterExchange,
-        message: deadMessage
+      this._emit('dead-letter', {
+        deadLetterExchange: this.options.deadLetterExchange,
+        message: deadMessage,
       });
     }
 
@@ -258,137 +318,153 @@ function Queue(name, options = {}, eventEmitter) {
     }
   }
 
-  function ackAll() {
-    getPendingMessages().forEach((msg) => msg.ack(false));
+  ackAll() {
+    this._getPendingMessages().forEach((msg) => msg.ack(false));
   }
 
-  function nackAll(requeue = true) {
-    getPendingMessages().forEach((msg) => msg.nack(false, requeue));
+  nackAll(requeue = true) {
+    this._getPendingMessages().forEach((msg) => msg.nack(false, requeue));
   }
 
-  function getPendingMessages(fromAndNotIncluding) {
-    if (!fromAndNotIncluding) return messages.filter((msg) => msg.pending);
+  _getPendingMessages(fromAndNotIncluding) {
+    if (!fromAndNotIncluding) return this.messages.filter((msg) => msg.pending);
 
-    const msgIdx = messages.indexOf(fromAndNotIncluding);
+    const msgIdx = this.messages.indexOf(fromAndNotIncluding);
     if (msgIdx === -1) return [];
 
-    return messages.slice(0, msgIdx).filter((msg) => msg.pending);
+    return this.messages.slice(0, msgIdx).filter((msg) => msg.pending);
   }
 
-  function requeueMessage(message) {
-    const msgIdx = messages.indexOf(message);
+  _requeueMessage(message) {
+    const msgIdx = this.messages.indexOf(message);
     if (msgIdx === -1) return;
-    pendingMessageCount++;
-    messages.splice(msgIdx, 1, Message({...message.fields, redelivered: true}, message.content, message.properties, onMessageConsumed));
+    this[prv].pendingMessageCount++;
+    this.messages.splice(
+      msgIdx,
+      1,
+      Message(
+        { ...message.fields, redelivered: true },
+        message.content,
+        message.properties,
+        this[prv].onMessageConsumed
+      )
+    );
   }
 
-  function peek(ignoreDelivered) {
-    const message = messages[0];
+  peek(ignoreDelivered) {
+    const message = this.messages[0];
     if (!message) return;
 
     if (!ignoreDelivered) return message;
     if (!message.pending) return message;
 
-    for (let idx = 1; idx < messages.length; idx++) {
-      if (!messages[idx].pending) {
-        return messages[idx];
+    for (let idx = 1; idx < this.messages.length; idx++) {
+      if (!this.messages[idx].pending) {
+        return this.messages[idx];
       }
     }
   }
 
-  function cancel(consumerTag) {
+  cancel(consumerTag) {
+    const consumers = this[prv].consumers;
     const idx = consumers.findIndex((c) => c.consumerTag === consumerTag);
     if (idx === -1) return;
 
-    return unbindConsumer(consumers[idx]);
+    return this.unbindConsumer(consumers[idx]);
   }
 
-  function dismiss(onMessage) {
-    const consumer = consumers.find((c) => c.onMessage === onMessage);
+  dismiss(onMessage) {
+    const consumer = this[prv].consumers.find((c) => c.onMessage === onMessage);
     if (!consumer) return;
-    unbindConsumer(consumer);
+    this.unbindConsumer(consumer);
   }
 
-  function unbindConsumer(consumer) {
-    const idx = consumers.indexOf(consumer);
+  unbindConsumer(consumer) {
+    const idx = this[prv].consumers.indexOf(consumer);
     if (idx === -1) return;
 
-    consumers.splice(idx, 1);
+    this[prv].consumers.splice(idx, 1);
 
-    if (exclusivelyConsumed) {
-      exclusivelyConsumed = false;
+    if (this[prv].exclusivelyConsumed) {
+      this[prv].exclusivelyConsumed = false;
     }
 
     consumer.stop();
 
-    if (options.autoDelete && !consumers.length) return deleteQueue();
+    if (this.options.autoDelete && !this[prv].consumers.length) {
+      return this.delete();
+    }
 
     consumer.nackAll(true);
   }
 
-  function emit(eventName, content) {
-    if (!eventEmitter || !eventEmitter.emit) return;
+  _emit(eventName, content) {
+    if (!this[prv].eventEmitter || !this[prv].eventEmitter.emit) return;
     const routingKey = `queue.${eventName}`;
-    eventEmitter.emit(routingKey, content);
+    this[prv].eventEmitter.emit(routingKey, content);
   }
 
-  function on(eventName, handler) {
-    if (!eventEmitter || !eventEmitter.on) return;
+  on(eventName, handler) {
+    if (!this[prv].eventEmitter || !this[prv].eventEmitter.on) return;
     const pattern = `queue.${eventName}`;
-    return eventEmitter.on(pattern, handler);
+    return this[prv].eventEmitter.on(pattern, handler);
   }
 
-  function off(eventName, handler) {
-    if (!eventEmitter || !eventEmitter.off) return;
+  off(eventName, handler) {
+    if (!this[prv].eventEmitter || !this[prv].eventEmitter.off) return;
     const pattern = `queue.${eventName}`;
-    return eventEmitter.off(pattern, handler);
+    return this[prv].eventEmitter.off(pattern, handler);
   }
 
-  function purge() {
-    const toDelete = messages.filter(({pending}) => !pending);
-    pendingMessageCount = 0;
+  purge() {
+    const toDelete = this.messages.filter(({ pending }) => !pending);
+    this[prv].pendingMessageCount = 0;
 
-    toDelete.forEach(dequeue);
+    toDelete.forEach((message) => this._dequeue(message));
 
-    if (!messages.length) emit('depleted', queue);
+    if (!this.messages.length) this._emit('depleted', this);
     return toDelete.length;
   }
 
-  function dequeueMessage(message) {
-    if (message.pending) return nack(message, false, false);
+  dequeueMessage(message) {
+    if (message.pending) return this.nack(message, false, false);
 
     message.consume({});
 
-    nack(message, false, false);
+    this.nack(message, false, false);
   }
 
-  function dequeue(message) {
-    const msgIdx = messages.indexOf(message);
+  _dequeue(message) {
+    const msgIdx = this.messages.indexOf(message);
     if (msgIdx === -1) return;
 
-    messages.splice(msgIdx, 1);
+    this.messages.splice(msgIdx, 1);
 
     return true;
   }
 
-  function getState() {
+  getState() {
     return {
-      name,
-      options: {...options},
-      ...(messages.length ? {messages: JSON.parse(JSON.stringify(messages))} : undefined),
+      name: this.name,
+      options: { ...this.options },
+      ...(this.messages.length
+        ? { messages: JSON.parse(JSON.stringify(this.messages)) }
+        : undefined),
     };
   }
 
-  function recover(state) {
-    stopped = false;
+  recover(state) {
+    this[prv].stopped = false;
+    const consumers = this[prv].consumers;
+
     if (!state) {
       consumers.slice().forEach((c) => c.recover());
-      return consumeNext();
+      return this._consumeNext();
     }
 
-    name = queue.name = state.name;
+    this.name = state.name;
 
-    messages.splice(0);
+    this.messages.splice(0);
 
     let continueConsume;
     if (consumers.length) {
@@ -396,192 +472,240 @@ function Queue(name, options = {}, eventEmitter) {
       continueConsume = true;
     }
 
-    if (!state.messages) return queue;
+    if (!state.messages) return this;
 
-    state.messages.forEach(({fields, content, properties}) => {
+    state.messages.forEach(({ fields, content, properties }) => {
       if (properties.persistent === false) return;
-      const msg = Message({...fields, redelivered: true}, content, properties, onMessageConsumed);
-      messages.push(msg);
+      const msg = Message(
+        { ...fields, redelivered: true },
+        content,
+        properties,
+        this[prv].onMessageConsumed
+      );
+      this.messages.push(msg);
     });
-    pendingMessageCount = messages.length;
+
+    this[prv].pendingMessageCount = this.messages.length;
     consumers.forEach((c) => c.recover());
     if (continueConsume) {
-      consumeNext();
+      this._consumeNext();
     }
 
-    return queue;
+    return this;
   }
 
-  function deleteQueue({ifUnused, ifEmpty} = {}) {
+  delete({ ifUnused, ifEmpty } = {}) {
+    const consumers = this[prv].consumers;
     if (ifUnused && consumers.length) return;
-    if (ifEmpty && messages.length) return;
+    if (ifEmpty && this.messages.length) return;
 
-    const messageCount = messages.length;
-    queue.stop();
+    const messageCount = this.messages.length;
+    this.stop();
 
     const deleteConsumers = consumers.splice(0);
     deleteConsumers.forEach((consumer) => {
       consumer.cancel();
     });
 
-    messages.splice(0);
+    this.messages.splice(0);
 
-    emit('delete', queue);
-    return {messageCount};
+    this._emit('delete', this);
+    return { messageCount };
   }
 
-  function close() {
-    consumers.splice(0).forEach((consumer) => consumer.cancel());
-    exclusivelyConsumed = false;
+  close() {
+    this[prv].consumers.splice(0).forEach((consumer) => consumer.cancel());
+    this[prv].exclusivelyConsumed = false;
   }
 
-  function stop() {
-    stopped = true;
-    consumers.slice().forEach((consumer) => consumer.stop());
+  stop() {
+    this[prv].stopped = true;
+    this.consumers.forEach((consumer) => consumer.stop());
   }
 
-  function getCapacity() {
-    return maxLength - messages.length;
+  getCapacity() {
+    return this.options.maxLength - this.messages.length;
   }
 }
 
-function Consumer(queue, onMessage, options = {}, owner, eventEmitter) {
-  if (typeof onMessage !== 'function') throw new Error('message callback is required and must be a function');
-  options = {prefetch: 1, priority: 0, noAck: false, ...options};
-  if (!options.consumerTag) options.consumerTag = `smq.ctag-${generateId()}`;
+function Queue(name, options = {}, eventEmitter) {
+  return new _Queue(name, options, eventEmitter);
+}
 
-  let ready = true, stopped = false, consuming;
-  const internalQueue = Queue(`${options.consumerTag}-q`, {maxLength: options.prefetch}, {emit: onInternalQueueEvent});
+const consumerPublicMethods = [
+  'on',
+  'ackAll',
+  'cancel',
+  'nackAll',
+  'prefetch',
+  'push',
+  'recover',
+  'stop',
+];
 
-  const consumer = {
-    queue,
-    get consumerTag() {
-      return options.consumerTag;
-    },
-    get messageCount() {
-      return internalQueue.messageCount;
-    },
-    get capacity() {
-      return internalQueue.capacity;
-    },
-    get queueName() {
-      return queue.name;
-    },
-    get ready() {
-      return ready && !stopped;
-    },
-    get stopped() {
-      return stopped;
-    },
-    options,
-    on,
-    onMessage,
-    ackAll,
-    cancel,
-    nackAll,
-    prefetch,
-    push,
-    recover,
-    stop,
-  };
+class _Consumer {
+  constructor(queue, onMessage, options = {}, owner, eventEmitter) {
+    this.options = { prefetch: 1, priority: 0, noAck: false, ...options };
+    if (!this.options.consumerTag) {
+      this.options.consumerTag = `smq.ctag-${generateId()}`;
+    }
 
-  return consumer;
+    const internalQueue = Queue(
+      `${this.options.consumerTag}-q`,
+      { maxLength: this.options.prefetch },
+      { emit: _Consumer.prototype._onInternalQueueEvent.bind(this) }
+    );
 
-  function push(messages) {
-    messages.forEach((message) => {
-      internalQueue.queueMessage(message.fields, message, message.properties, onInternalMessageQueued);
+    this[prv] = {
+      eventEmitter,
+      owner,
+      internalQueue,
+      ready: true,
+      stopped: false,
+      consuming: undefined,
+      onInternalMessageQueued:
+        _Consumer.prototype._onInternalMessageQueued.bind(this),
+    };
+
+    this.queue = queue;
+    this.onMessage = onMessage;
+
+    consumerPublicMethods.forEach((fn) => {
+      this[fn] = _Consumer.prototype[fn].bind(this);
     });
-    if (!consuming) {
-      consume();
+  }
+
+  get consumerTag() {
+    return this.options.consumerTag;
+  }
+
+  get messageCount() {
+    return this[prv].internalQueue.messageCount;
+  }
+
+  get capacity() {
+    return this[prv].internalQueue.capacity;
+  }
+
+  get queueName() {
+    return this.queue.name;
+  }
+
+  get ready() {
+    return this[prv].ready && !this[prv].stopped;
+  }
+
+  get stopped() {
+    return this[prv].stopped;
+  }
+
+  on(eventName, handler) {
+    const pattern = `consumer.${eventName}`;
+    return this[prv].eventEmitter.on(pattern, handler);
+  }
+
+  ackAll() {
+    this[prv].internalQueue.messages.slice().forEach((msg) => {
+      msg.content.ack(false);
+    });
+  }
+
+  cancel(requeue = true) {
+    this._emit('cancel', this);
+    this.nackAll(requeue);
+  }
+
+  nackAll(requeue) {
+    this[prv].internalQueue.messages.slice().forEach((msg) => {
+      msg.content.nack(false, requeue);
+    });
+  }
+
+  prefetch(value) {
+    this.options.prefetch = this[prv].internalQueue.maxLength = value;
+  }
+
+  push(messages) {
+    const { internalQueue, onInternalMessageQueued } = this[prv];
+    messages.forEach((message) => {
+      internalQueue.queueMessage(
+        message.fields,
+        message,
+        message.properties,
+        onInternalMessageQueued
+      );
+    });
+    if (!this[prv].consuming) {
+      this._consume();
     }
   }
 
-  function onInternalMessageQueued(msg) {
-    const message = msg.content;
-    message.consume(options, onConsumed);
-
-    function onConsumed() {
-      internalQueue.dequeueMessage(msg);
-    }
+  recover() {
+    this[prv].stopped = false;
   }
 
-  function consume() {
-    if (stopped) return;
-    consuming = true;
+  stop() {
+    this[prv].stopped = true;
+  }
 
-    const msg = internalQueue.get();
+  /* private methods */
+
+  _emit(eventName, content) {
+    const routingKey = `consumer.${eventName}`;
+    this[prv].eventEmitter.emit(routingKey, content);
+  }
+
+  _consume() {
+    if (this[prv].stopped) return;
+    this[prv].consuming = true;
+
+    const msg = this[prv].internalQueue.get();
 
     if (!msg) {
-      consuming = false;
+      this[prv].consuming = false;
       return;
     }
 
-    msg.consume(options);
+    msg.consume(this.options);
     const message = msg.content;
-    message.consume(options, onConsumed);
+    message.consume(this.options, onConsumed);
 
-    if (options.noAck) msg.content.ack();
-    onMessage(msg.fields.routingKey, msg.content, owner);
+    if (this.options.noAck) msg.content.ack();
+    this.onMessage(msg.fields.routingKey, msg.content, this[prv].owner);
 
-    consuming = false;
+    this[prv].consuming = false;
 
-    return consume();
+    return this._consume();
 
     function onConsumed() {
       msg.nack(false, false);
     }
   }
 
-  function onInternalQueueEvent(eventName) {
+  _onInternalMessageQueued(msg) {
+    const message = msg.content;
+    const internalQueue = this[prv].internalQueue;
+    message.consume(this.options, () => internalQueue.dequeueMessage(msg));
+  }
+
+  _onInternalQueueEvent(eventName) {
     switch (eventName) {
       case 'queue.saturated': {
-        ready = false;
+        this[prv].ready = false;
         break;
       }
       case 'queue.depleted':
       case 'queue.ready':
-        ready = true;
+        this[prv].ready = true;
         break;
     }
   }
-
-  function nackAll(requeue) {
-    internalQueue.messages.slice().forEach((msg) => {
-      msg.content.nack(false, requeue);
-    });
-  }
-
-  function ackAll() {
-    internalQueue.messages.slice().forEach((msg) => {
-      msg.content.ack(false);
-    });
-  }
-
-  function cancel(requeue = true) {
-    emit('cancel', consumer);
-    nackAll(requeue);
-  }
-
-  function prefetch(value) {
-    options.prefetch = internalQueue.maxLength = value;
-  }
-
-  function emit(eventName, content) {
-    const routingKey = `consumer.${eventName}`;
-    eventEmitter.emit(routingKey, content);
-  }
-
-  function on(eventName, handler) {
-    const pattern = `consumer.${eventName}`;
-    return eventEmitter.on(pattern, handler);
-  }
-
-  function recover() {
-    stopped = false;
-  }
-
-  function stop() {
-    stopped = true;
-  }
 }
 
+function Consumer(queue, onMessage, options = {}, owner, eventEmitter) {
+  if (typeof onMessage !== 'function') {
+    throw new Error('message callback is required and must be a function');
+  }
+
+  return new _Consumer(queue, onMessage, options, owner, eventEmitter);
+}

--- a/src/Shovel.js
+++ b/src/Shovel.js
@@ -1,85 +1,110 @@
-import {EventExchange} from './Exchange';
+import { EventExchange } from './Exchange';
 
-export function Shovel(name, source, destination, options = {}) {
-  const {broker: sourceBroker, exchange: sourceExchangeName, pattern, queue, priority} = source;
-  const {broker: destinationBroker, exchange: destinationExchangeName, publishProperties, exchangeKey} = destination;
-  const {cloneMessage} = options;
 
-  const sourceExchange = sourceBroker.getExchange(sourceExchangeName);
-  if (!sourceExchange) {
-    throw new Error(`shovel ${name} source exchange <${sourceExchangeName}> not found`);
+const prv = Symbol('private');
+
+const shovelPublicMethods = [
+  'close',
+];
+
+class _Shovel {
+  constructor(name, source, destination, options = {}) {
+    const { broker: sourceBroker, exchange: sourceExchangeName, pattern, queue, priority } = source;
+    const { broker: destinationBroker, exchange: destinationExchangeName, publishProperties, exchangeKey } = destination;
+    const { cloneMessage } = options;
+
+    const sourceExchange = sourceBroker.getExchange(sourceExchangeName);
+    if (!sourceExchange) {
+      throw new Error(`shovel ${name} source exchange <${sourceExchangeName}> not found`);
+    }
+
+    const destinationExchange = destinationBroker.getExchange(destinationExchangeName);
+    if (!destinationExchange) {
+      throw new Error(`shovel ${name} destination exchange <${destinationExchangeName}> not found`);
+    }
+
+    shovelPublicMethods.forEach((fn) => {
+      this[fn] = _Shovel.prototype[fn].bind(this);
+    });
+
+    const eventHandlers = [
+      sourceExchange.on('delete', this.close),
+      destinationExchange.on('delete', this.close),
+    ];
+
+    const consumerTag = source.consumerTag || `smq.shoveltag-${name}`;
+    const routingKeyPattern = pattern || '#';
+
+    this[prv] = {
+      sameBroker: sourceBroker === destinationBroker,
+      events: EventExchange(),
+      closed: false,
+      cloneMessage,
+      destination,
+      destinationExchange,
+      eventHandlers,
+      exchangeKey,
+      publishProperties,
+      sourceBroker,
+      sourceExchangeName,
+    };
+
+    this.name = name;
+    this.source = { ...source, pattern: routingKeyPattern };
+    this.destination = { ...destination };
+    this.consumerTag = consumerTag;
+    this.on = this[prv].events.on;
+
+    const onShovelMessage = _Shovel.prototype.onShovelMessage.bind(this);
+    let consumer;
+    if (queue) {
+      consumer = sourceBroker.subscribe(sourceExchangeName, routingKeyPattern, queue, onShovelMessage, { consumerTag, priority });
+    } else {
+      consumer = sourceBroker.subscribeTmp(sourceExchangeName, routingKeyPattern, onShovelMessage, { consumerTag, priority });
+      this.source.queue = consumer.queue.name;
+    }
+    eventHandlers.push(consumer.on('cancel', this.close));
   }
 
-  const destinationExchange = destinationBroker.getExchange(destinationExchangeName);
-  if (!destinationExchange) {
-    throw new Error(`shovel ${name} destination exchange <${destinationExchangeName}> not found`);
+  get closed() {
+    return this[prv].closed;
   }
 
-  const sameBroker = sourceBroker === destinationBroker;
-  const consumerTag = source.consumerTag || `smq.shoveltag-${name}`;
-  const routingKeyPattern = pattern || '#';
-  const events = EventExchange();
-
-  let closed = false;
-  const api = {
-    name,
-    get closed() {
-      return closed;
-    },
-    source: {...source, pattern: routingKeyPattern},
-    destination: {...destination},
-    consumerTag,
-    close,
-    on: events.on,
-  };
-
-  const eventHandlers = [
-    sourceExchange.on('delete', close),
-    destinationExchange.on('delete', close),
-  ];
-
-  let consumer;
-  if (queue) {
-    consumer = sourceBroker.subscribe(sourceExchangeName, routingKeyPattern, queue, onShovelMessage, {consumerTag, priority});
-  } else {
-    consumer = sourceBroker.subscribeTmp(sourceExchangeName, routingKeyPattern, onShovelMessage, {consumerTag, priority});
-    api.source.queue = consumer.queue.name;
-  }
-  eventHandlers.push(consumer.on('cancel', close));
-
-  return api;
-
-  function onShovelMessage(routingKey, message) {
-    const {content, properties} = messageHandler(message);
-    const props = {...properties, ...publishProperties, 'source-exchange': sourceExchangeName};
-    if (!sameBroker) props['shovel-name'] = name;
-    destinationExchange.publish(exchangeKey || routingKey, content, props);
+  onShovelMessage(routingKey, message) {
+    const { content, properties } = this.messageHandler(message);
+    const props = { ...properties, ...this[prv].publishProperties, 'source-exchange': this[prv].sourceExchangeName };
+    if (!this[prv].sameBroker) props['shovel-name'] = this.name;
+    this[prv].destinationExchange.publish(this[prv].exchangeKey || routingKey, content, props);
     message.ack();
   }
 
-  function close() {
-    if (closed) return;
-    closed = true;
-    eventHandlers.splice(0).forEach((e) => e.cancel());
-    events.emit('close', api);
-    events.close();
-    sourceBroker.cancel(consumerTag);
+  close() {
+    if (this[prv].closed) return;
+    this[prv].closed = true;
+    this[prv].eventHandlers.splice(0).forEach((e) => e.cancel());
+    this[prv].events.emit('close', this);
+    this[prv].events.close();
+    this[prv].sourceBroker.cancel(this.consumerTag);
   }
 
-  function messageHandler(message) {
-    if (!cloneMessage) return message;
+  messageHandler(message) {
+    if (!this[prv].cloneMessage) return message;
 
-    const {fields, content, properties} = message;
-    const {content: newContent, properties: newProperties} = cloneMessage({
-      fields: {...fields},
+    const { fields, content, properties } = message;
+    const { content: newContent, properties: newProperties } = this[prv].cloneMessage({
+      fields: { ...fields },
       content,
-      properties: {...properties},
+      properties: { ...properties },
     });
 
     return {
       fields,
       content: newContent,
-      properties: {...properties, ...newProperties},
+      properties: { ...properties, ...newProperties },
     };
   }
+}
+
+export function Shovel(name, source, destination, options = {}) {
+  return new _Shovel(name, source, destination, options);
 }

--- a/test/Broker-test.js
+++ b/test/Broker-test.js
@@ -9,6 +9,58 @@ describe('Broker', () => {
 
       expect(broker.owner).to.equal(owner);
     });
+
+    it('should export only enumerable properties', () => {
+      const enumerableProperties = [
+        'owner',
+        'subscribe',
+        'subscribeOnce',
+        'subscribeTmp',
+        'unsubscribe',
+        'createShovel',
+        'closeShovel',
+        'getShovel',
+        'assertExchange',
+        'ack',
+        'ackAll',
+        'nack',
+        'nackAll',
+        'cancel',
+        'close',
+        'deleteExchange',
+        'bindExchange',
+        'bindQueue',
+        'assertQueue',
+        'consume',
+        'createQueue',
+        'deleteQueue',
+        'get',
+        'getConsumer',
+        'getConsumers',
+        'getExchange',
+        'getQueue',
+        'getState',
+        'on',
+        'off',
+        'prefetch',
+        'publish',
+        'purgeQueue',
+        'recover',
+        'reject',
+        'reset',
+        'sendToQueue',
+        'stop',
+        'unbindExchange',
+        'unbindQueue',
+        'exchangeCount',
+        'queueCount',
+        'consumerCount',
+      ];
+      const broker = Broker();
+      const keys = Object.keys(broker);
+
+      expect(keys).deep.to.equal(enumerableProperties);
+    });
   });
 
   describe('subscribe()', () => {

--- a/test/Broker-test.js
+++ b/test/Broker-test.js
@@ -13,6 +13,10 @@ describe('Broker', () => {
     it('should export only enumerable properties', () => {
       const enumerableProperties = [
         'owner',
+        // XXX non enumerable getters
+        // 'exchangeCount',
+        // 'queueCount',
+        // 'consumerCount',
         'subscribe',
         'subscribeOnce',
         'subscribeTmp',
@@ -34,7 +38,6 @@ describe('Broker', () => {
         'consume',
         'createQueue',
         'deleteQueue',
-        'get',
         'getConsumer',
         'getConsumers',
         'getExchange',
@@ -42,7 +45,6 @@ describe('Broker', () => {
         'getState',
         'on',
         'off',
-        'prefetch',
         'publish',
         'purgeQueue',
         'recover',
@@ -52,9 +54,8 @@ describe('Broker', () => {
         'stop',
         'unbindExchange',
         'unbindQueue',
-        'exchangeCount',
-        'queueCount',
-        'consumerCount',
+        'prefetch',
+        'get',
       ];
       const broker = Broker();
       const keys = Object.keys(broker);

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -1,6 +1,7 @@
 import {Broker} from '../index';
 import {Message} from '../src/Message';
 import ck from 'chronokinesis';
+import { expect } from 'chai';
 
 describe('message', () => {
   after(ck.reset);
@@ -97,5 +98,13 @@ describe('message', () => {
     const msg = Message();
     msg.consume();
     expect(msg).to.have.property('consumerTag', undefined);
+  });
+
+  it('should export only enumerable properties', () => {
+    const enumerableProperties = ['fields', 'content', 'properties', 'consume', 'ack', 'nack', 'reject'];
+    const msg = Message();
+    const keys = Object.keys(msg);
+
+    expect(keys).deep.to.equal(enumerableProperties);
   });
 });

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -777,7 +777,7 @@ describe('Broker queue', () => {
 
       expect(queue.getState()).to.deep.equal({
         name: 'test-q',
-        options: { autoDelete: true, durable: true },
+        options: { autoDelete: true, durable: true, maxLength: Infinity },
       });
     });
 

--- a/test/src/Exchange-test.js
+++ b/test/src/Exchange-test.js
@@ -27,6 +27,32 @@ describe('Exchange', () => {
         Exchange('event', {});
       }).to.throw();
     });
+
+    it('should export only enumerable properties', () => {
+      const enumerableProperties = [
+        'name',
+        'type',
+        'options',
+        'bind',
+        'close',
+        'emit',
+        'getBinding',
+        'getState',
+        'on',
+        'off',
+        'publish',
+        'recover',
+        'stop',
+        'unbind',
+        'unbindQueueByName',
+        'bindingCount',
+        'bindings',
+        'stopped',
+      ];
+      const exchange = Exchange('test');
+      const keys = Object.keys(exchange);
+      expect(keys).deep.to.equal(enumerableProperties);
+    });
   });
 
   describe('direct exchange', () => {

--- a/test/src/Exchange-test.js
+++ b/test/src/Exchange-test.js
@@ -33,6 +33,10 @@ describe('Exchange', () => {
         'name',
         'type',
         'options',
+        // XXX non enumerable getters
+        // 'bindingCount',
+        // 'bindings',
+        // 'stopped',
         'bind',
         'close',
         'emit',
@@ -45,9 +49,6 @@ describe('Exchange', () => {
         'stop',
         'unbind',
         'unbindQueueByName',
-        'bindingCount',
-        'bindings',
-        'stopped',
       ];
       const exchange = Exchange('test');
       const keys = Object.keys(exchange);

--- a/test/src/Queue-test.js
+++ b/test/src/Queue-test.js
@@ -14,12 +14,12 @@ describe('Queue', () => {
 
     it('takes options', () => {
       const queue = Queue(null, {autoDelete: false, durable: true});
-      expect(queue).to.have.property('options').that.eql({autoDelete: false, durable: true});
+      expect(queue).to.have.property('options').that.eql({autoDelete: false, durable: true, maxLength: Infinity});
     });
 
     it('defaults to option autoDelete if not passed', () => {
       const queue = Queue();
-      expect(queue).to.have.property('options').that.eql({autoDelete: true});
+      expect(queue).to.have.property('options').that.eql({autoDelete: true, maxLength: Infinity});
     });
 
     it('should export only enumerable properties', () => {
@@ -49,7 +49,8 @@ describe('Queue', () => {
         'reject',
         'stop',
         'unbindConsumer',
-        'messageCount',
+        // XXX non enumerable getter
+        // 'messageCount',
       ];
       const queue = Queue();
       const keys = Object.keys(queue);
@@ -960,7 +961,8 @@ describe('Queue', () => {
       const state = queue.getState();
       expect(state).to.have.property('name', 'test-q');
       expect(state).to.have.property('options').that.eql({
-        autoDelete: true
+        autoDelete: true,
+        maxLength: Infinity,
       });
       expect(state).to.have.property('messages').have.length(2);
     });

--- a/test/src/Queue-test.js
+++ b/test/src/Queue-test.js
@@ -21,6 +21,40 @@ describe('Queue', () => {
       const queue = Queue();
       expect(queue).to.have.property('options').that.eql({autoDelete: true});
     });
+
+    it('should export only enumerable properties', () => {
+      const enumerableProperties = [
+        'name',
+        'options',
+        'messages',
+        'ack',
+        'ackAll',
+        'assertConsumer',
+        'cancel',
+        'close',
+        'consume',
+        'delete',
+        'dequeueMessage',
+        'dismiss',
+        'get',
+        'getState',
+        'nack',
+        'nackAll',
+        'off',
+        'on',
+        'peek',
+        'purge',
+        'queueMessage',
+        'recover',
+        'reject',
+        'stop',
+        'unbindConsumer',
+        'messageCount',
+      ];
+      const queue = Queue();
+      const keys = Object.keys(queue);
+      expect(keys).deep.to.equal(enumerableProperties);
+    });
   });
 
   describe('queue options', () => {


### PR DESCRIPTION
Hi!

I've been working with my colleague @roberto-naharro on this pull request to further optimize SMQP.

The results are quite impressive already. In our real world use case, using this version of SMQP reduces in half the execution time of BPMN-Engine, and micro-benchmarks for only the optimized code have roughly a 4x speedup.

We have extracted as much code as possible to the prototype, which greatly increases the object creation performance (given that objects have a much smaller footprint, and there is less dynamic code to optimize by the JIT compiler).

There are some minor changes to the exposed interface, namely that getters are not enumerable anymore (because the descriptors live in the prototype rather than in the instances). That means that they don't appear anymore when doing a `for (prop in instance)` or in a `JSON.stringify(instance)` (which seems correct, as they are computed transient values), but they are as accessible as before.

Another small change that doesn't break the interface but needed to update some tests is that `maxCapacity` in Queue defaults to `Infinity` in the constructor, rather than when being accessed.

We hope you like the changes, and please do not hesitate to give us any feedback you have! :-)